### PR TITLE
feat: extend highlights and locals and set indents

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -6,8 +6,8 @@
 
 ; Functions
 
-(function_call function: (identifier) @function)
-(module_call name: (identifier) @function)
+(function_call function: (identifier) @function (#set! "priority" 105))
+(module_call name: (identifier) @function (#set! "priority" 105))
 
 ; Variables
 
@@ -20,41 +20,76 @@
 ; Keywords
 
 [
-  "module"
-  "function"
-  "let"
-  "assign"
-  "use"
-  "each"
-] @keyword
+ "module"
+ "function"
+ "let"
+ "assign"
+ "use"
+ "each"
+ ] @keyword
 
 ; Operators
 
 [
-  "||"
-  "&&"
-  "=="
-  "!="
-  "<"
-  ">"
-  "<="
-  ">="
-  "+"
-  "-"
-  "*"
-  "/"
-  "%"
-  "^"
-  "!"
-  ":"
-] @operator
+ "||"
+ "&&"
+ "=="
+ "!="
+ "<"
+ ">"
+ "<="
+ ">="
+ "+"
+ "-"
+ "*"
+ "/"
+ "%"
+ "^"
+ "!"
+ ":"
+ ] @operator
+
+; Builtins
+
+((identifier) @function.builtin
+			  (#any-of? @function.builtin
+			   "union"
+			   "difference"
+			   "intersection"
+			   "circle"
+			   "square"
+			   "polygon"
+			   "text"
+			   "import"
+			   "projection"
+			   "sphere"
+			   "cube"
+			   "cylinder"
+			   "polyhedron"
+			   "linear_extrude"
+			   "rotate_extrude"
+			   "surface"
+			   "translate"
+			   "rotate"
+			   "scale"
+			   "resize"
+			   "mirror"
+			   "multmatrix"
+			   "color"
+			   "offset"
+			   "hull"
+			   "minkowski"
+			   ))
+
+((identifier) @identifier
+			  (#eq? @identifier "PI")) @constant.builtin
 
 ; Conditionals
 
 [
-  "if"
-  "else"
-] @conditional
+ "if"
+ "else"
+ ] @conditional
 
 (ternary_expression
   ["?" ":"] @conditional.ternary)
@@ -62,9 +97,9 @@
 ; Repeats
 
 [
-  "for"
-  "intersection_for"
-] @repeat
+ "for"
+ "intersection_for"
+ ] @repeat
 
 ; Literals
 
@@ -79,8 +114,8 @@
 ; Misc
 
 [
-  "#"
-] @punctuation.special
+ "#"
+ ] @punctuation.special
 
 ["{" "}"] @punctuation.bracket
 
@@ -89,10 +124,10 @@
 ["[" "]"] @punctuation.bracket
 
 [
-  ";"
-  ","
-  "."
-] @punctuation.delimiter
+ ";"
+ ","
+ "."
+ ] @punctuation.delimiter
 
 ; Comments
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -1,8 +1,8 @@
 ; Includes
 
-"include" @include
+"include" @keyword.import
 
-(include_path) @string
+(include_path) @markup.raw
 
 ; Functions
 
@@ -89,25 +89,25 @@
 [
  "if"
  "else"
- ] @conditional
+ ] @keyword.conditional
 
 (ternary_expression
-  ["?" ":"] @conditional.ternary)
+  ["?" ":"] @keyword.conditional.ternary)
 
 ; Repeats
 
 [
  "for"
  "intersection_for"
- ] @repeat
+ ] @keyword.repeat
 
 ; Literals
 
 (decimal) @number
 
-(float) @float
+(float) @number.float
 
-(string) @string
+(string) @markup.raw
 
 (boolean) @boolean
 

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -2,7 +2,7 @@
 
 "include" @keyword.import
 
-(include_path) @markup.raw
+(include_path) @string
 
 ; Functions
 
@@ -107,7 +107,7 @@
 
 (float) @number.float
 
-(string) @markup.raw
+(string) @string
 
 (boolean) @boolean
 

--- a/queries/indents.scm
+++ b/queries/indents.scm
@@ -1,0 +1,16 @@
+[
+ (module_declaration)
+ (union_block)
+ (if_block)
+ (for_block)
+ ] @indent.begin
+
+[
+ "}"
+ ")"
+ ] @indent.end
+
+(arguments ")" @indent.branch)
+(parameters_declaration ")" @indent.branch)
+
+(comment) @indent.ignore

--- a/queries/locals.scm
+++ b/queries/locals.scm
@@ -1,0 +1,25 @@
+(
+ (module_declaration
+   name: (identifier) @local.definition.function)
+ )
+
+(
+ (assignment left: (identifier) @local.definition.var)
+ )
+
+(((parameter) (identifier)) @local.definition.var)
+
+;; reference
+(identifier) @local.reference
+
+;; Call references
+((module_call
+   name: (identifier) @local.reference)
+ (#set! reference.kind "call" ))
+
+;; Scopes
+(module_declaration) @local.scope
+(transform_chain) @local.scope
+(union_block) @local.scope
+(if_block) @local.scope
+(for_block) @local.scope


### PR DESCRIPTION
I extended the `highlight.scm` with builtins, filled `locals.scm` and added `indents.scm`.

These are most likely not complete this way but they are at least more complete than before. ;-) 